### PR TITLE
Enable a child theme with decreased amounts of hassle

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -74,3 +74,44 @@ function enqueue_scripts() {
 function content_width() {
 	$GLOBALS['content_width'] = 640;
 }
+
+/**
+ * Retrieve the URL of a file in the theme.
+ *
+ * Searches in the stylesheet directory before the template directory so themes
+ * which inherit from a parent theme can just override one file.
+ *
+ * @param string $file File to search for in the stylesheet directory.
+ * @return string The URL of the file.
+ */
+function get_theme_file_uri( $file = '' ) {
+	$file = ltrim( $file, '/' );
+
+	if ( empty( $file ) ) {
+		$url = get_stylesheet_directory_uri();
+	} elseif ( file_exists( get_stylesheet_directory() . '/' . $file ) ) {
+		$url = get_stylesheet_directory_uri() . '/' . $file;
+	} else {
+		$url = get_template_directory_uri() . '/' . $file;
+	}
+
+	return $url;
+}
+
+/**
+ * Retrieve the URL of a file in the parent theme.
+ *
+ * @param string $file File to return the URL for in the template directory.
+ * @return string The URL of the file.
+ */
+function get_parent_theme_file_uri( $file = '' ) {
+	$file = ltrim( $file, '/' );
+
+	if ( empty( $file ) ) {
+		$url = get_template_directory_uri();
+	} else {
+		$url = get_template_directory_uri() . '/' . $file;
+	}
+
+	return $url;
+}

--- a/functions.php
+++ b/functions.php
@@ -53,9 +53,9 @@ function setup() {
  */
 function enqueue_scripts() {
 
-	wp_register_script( 'hm-pattern-lib', get_stylesheet_directory_uri() . '/vendor/hm-pattern-library/assets/js/app.js', [], '1.0', true );
-	wp_enqueue_script( 'hm-handbook', get_stylesheet_directory_uri() . '/assets/dist/scripts/theme.js', [ 'hm-pattern-lib' ], '1.0', true );
-	wp_enqueue_style( 'hm-handbook', get_stylesheet_directory_uri() . '/assets/dist/styles/theme.css', [], '1.0' );
+	wp_register_script( 'hm-pattern-lib', get_parent_theme_file_uri( 'vendor/hm-pattern-library/assets/js/app.js' ), [], '1.0', true );
+	wp_enqueue_script( 'hm-handbook', get_theme_file_uri( 'assets/dist/scripts/theme.js' ), [ 'hm-pattern-lib' ], '1.0', true );
+	wp_enqueue_style( 'hm-handbook', get_theme_file_uri( 'assets/dist/styles/theme.css' ), [], '1.0' );
 
 	add_action( 'wp_head', function() {
 		echo '<script src="https://use.typekit.net/mwe8dvt.js"></script>';


### PR DESCRIPTION
If you make a child theme with `hm-handbook` as its parent, you have to copy all the built CSS and JS files over otherwise they all 404. This is due to the use of `get_stylesheet_directory_uri()` when enqueuing the assts.

Switching to `get_template_directory_uri()` doesn't _really_ solve the problem, because a child theme should be able to optionally override an enqueued asset.

Anyway, this is old news. [This five year old ticket opened by yours truly on core Trac provides the solution](https://core.trac.wordpress.org/ticket/18302).

This PR adds those functions into our namespace and switches the `hm-handbook` CSS and JS to conditionally load from the child or parent theme, and the `hm-pattern-lib` to explicitly load from the parent theme.

Good times.