### PR TITLE
Add edtor styles

### DIFF
--- a/assets/src/styles/components/_content.scss
+++ b/assets/src/styles/components/_content.scss
@@ -6,5 +6,4 @@
 		padding: ( $base-line-height * 2 ) ( $gutter-width * 2 );
 		max-width: calc( 40rem + #{ $gutter-width * 4 } );
 	}
-
 }

--- a/assets/src/styles/editor.scss
+++ b/assets/src/styles/editor.scss
@@ -1,0 +1,36 @@
+$hm-images: "./../../../vendor/hm-pattern-library/assets/images";
+
+// External
+@import "./../../../vendor/hm-pattern-library/assets/sass/style";
+
+// Base
+@import "base/variables";
+@import "base/fonts";
+
+.mce-content-body {
+	max-width: 90%;
+	max-width: calc( 40rem + #{ $gutter-width * 2 } );
+	margin-left: auto;
+	margin-right: auto;
+	-webkit-font-smoothing: auto !important;
+}
+
+table {
+	margin: $base-line-height auto;
+}
+
+.mce-item-table {
+	border: none;
+}
+
+.mce-item-table td {
+	@extend td;
+	border-top: none;
+	border-left: none;
+}
+
+.mce-item-table th {
+	@extend td;
+	border-top: none;
+	border-left: none;
+}

--- a/functions.php
+++ b/functions.php
@@ -16,6 +16,7 @@ require_once( __DIR__ . '/inc/search.php' );
 add_action( 'after_setup_theme',  __NAMESPACE__ . '\\setup' );
 add_action( 'after_setup_theme',  __NAMESPACE__ . '\\content_width', 0 );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
+add_action( 'admin_init',         __NAMESPACE__ . '\\setup_admin' );
 
 /**
  * Set up the theme.
@@ -37,6 +38,18 @@ function setup() {
 	// Filter next/prev post classes.
 	add_filter( 'next_posts_link_attributes',     __NAMESPACE__ . '\\posts_link_attributes' );
 	add_filter( 'previous_posts_link_attributes', __NAMESPACE__ . '\\posts_link_attributes' );
+
+
+}
+
+function setup_admin() {
+
+	add_editor_style( 'assets/dist/styles/editor.css' );
+
+	add_filter( 'mce_external_plugins', function( $plugin_array ) {
+		$plugin_array['typekit'] = get_template_directory_uri() . '/inc/tinyMCE/tinyMCE-typekit.js';
+		return $plugin_array;
+	} );
 
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,8 +51,8 @@ gulp.task( 'js', function( callback ) {
 	);
 });
 
-gulp.task( 'lint', function () {
-  return gulp.src( './assets/src/styles/**/*.s+(a|c)ss')
+gulp.task( 'lint-sass', function () {
+  return gulp.src( [ './assets/src/styles/**/*.s+(a|c)ss', '!./assets/src/styles/editor.scss' ] )
 	.pipe( sassLint( { configFile: '.sass-lint.yml' } ) )
 	.pipe( sassLint.format() )
 	.pipe( sassLint.failOnError() )
@@ -60,9 +60,9 @@ gulp.task( 'lint', function () {
 
 // Watch for changes in JS/CSS.
 gulp.task('watch', function() {
-	gulp.watch( 'assets/src/styles/**/*.scss', ['styles'] );
+	gulp.watch( 'assets/src/styles/**/*.scss', ['styles', 'lint-sass' ] );
 	gulp.watch( [ 'assets/src/scripts/**/*.js', 'assets/src/scripts/**/*.jsx' ], ['js'] );
 });
 
 // Tasks
-gulp.task( 'default', [ 'styles', 'js', 'lint' ] );
+gulp.task( 'default', [ 'styles', 'js', 'lint-sass' ] );

--- a/inc/tinyMCE/tinyMCE-typekit.js
+++ b/inc/tinyMCE/tinyMCE-typekit.js
@@ -1,0 +1,47 @@
+/* global tinymce */
+tinymce.PluginManager.add( 'typekit', function( editor ) {
+
+	function addScriptToHead() {
+		// Get the DOM document object for the IFRAME
+		var doc = editor.getDoc();
+
+		// Create the script we will add to the header asynchronously
+		var jscript = "(function() {\n\
+			var config = {\n\
+				kitId: 'mwe8dvt'\n\
+			};\n\
+			var d = false;\n\
+			var tk = document.createElement('script');\n\
+			tk.src = '//use.typekit.net/' + config.kitId + '.js';\n\
+			tk.type = 'text/javascript';\n\
+			tk.async = 'true';\n\
+			tk.onload = tk.onreadystatechange = function() {\n\
+				var rs = this.readyState;\n\
+				if (d || rs && rs != 'complete' && rs != 'loaded') return;\n\
+				d = true;\n\
+				try { Typekit.load(config); } catch (e) {}\n\
+			};\n\
+			var s = document.getElementsByTagName('script')[0];\n\
+			s.parentNode.insertBefore(tk, s);\n\
+		})();";
+
+		// Create a script element and insert the TypeKit code into it
+		var script = doc.createElement( 'script' );
+		script.type = 'text/javascript';
+		script.appendChild( doc.createTextNode( jscript ) );
+
+		// Add the script to the header
+		doc.getElementsByTagName( 'head' )[0].appendChild( script );
+	}
+
+	// Support both TinyMCE 3 and 4.
+	if ( 3 < parseInt( tinymce.majorVersion ) ) {
+		editor.on( 'preInit', function() {
+			addScriptToHead();
+		});
+	} else {
+		editor.onPreInit.add( function( editor ) {
+			addScriptToHead();
+		});
+	}
+});


### PR DESCRIPTION
https://github.com/humanmade/hm-handbook-theme/issues/7

Only issue is I have to ignore the file from `SASS-lint` because autoprefixer doesn't support `-webkit-font-smoothing`, and i"ve had to use `!important` to beat the default WP style that also uses `!important`