### PR TITLE
Tidy admin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,6 +12,7 @@ namespace HM_Handbook;
 require_once( __DIR__ . '/inc/primary-nav.php' );
 require_once( __DIR__ . '/inc/page-history.php' );
 require_once( __DIR__ . '/inc/search.php' );
+require_once( __DIR__ . '/inc/editor-mods.php' );
 
 add_action( 'after_setup_theme',  __NAMESPACE__ . '\\setup' );
 add_action( 'after_setup_theme',  __NAMESPACE__ . '\\content_width', 0 );
@@ -26,8 +27,8 @@ function setup() {
 	// Let WordPress manage the document title.
 	add_theme_support( 'title-tag' );
 
-	// Enable support for Post Thumbnails on posts and pages.
-	add_theme_support( 'post-thumbnails' );
+	// Disable support for Post Thumbnails on posts and pages.
+	remove_theme_support( 'post-thumbnails' );
 
 	// Switch default core markup for search form, comment form, and comments to output valid HTML5.
 	add_theme_support( 'html5', [ 'search-form', 'comment-form', 'comment-list', 'gallery', 'caption' ]	);

--- a/inc/editor-mods.php
+++ b/inc/editor-mods.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace HM_Handbook;
+
+/**
+ * Modify TinyMCE4 configurations.
+ *
+ * @param  array $mceInit config
+ * @param  int $editor_id
+ * @return array $mceInit
+ */
+function modify_tinyMCE4( $mceInit, $editor_id ) {
+
+	// Set the allowed 'Blog formats' - remove h1
+	$mceInit['block_formats'] = "Paragraph=p;Header 2=h2;Header 3=h3;Header 4=h4;Preformatted=pre";
+
+	// Could just the required buttons on each toolbar if we want.
+	// But other plugins may be making modifications so I'm going to and avoid breaking things.
+	// Toolbar buttons are stored as a comma separated list - lets make them an array.
+	$toolbar1 = explode( ',', $mceInit['toolbar1'] );
+	$toolbar2 = explode( ',', $mceInit['toolbar2'] );
+
+	// These are all the buttons we want to completely remove.
+	$remove = array(
+		'underline',
+		'forecolor',
+		'alignjustify',
+		'alignleft',
+		'aligncenter',
+		'alignright',
+		'indent',
+		'outdent',
+		'wp_more',
+		'hr',
+		'strikethrough',
+	);
+
+	// Remove these buttons if they are found in toolbar1 or toolbar2
+	foreach ( $remove as $name ) {
+		if ( $key = array_search( $name, $toolbar1 ) ) {
+			unset( $toolbar1[$key] );
+		}
+		if ( $key = array_search( $name, $toolbar2 ) ) {
+			unset( $toolbar2[$key] );
+		}
+	}
+
+	// Insert some new buttons.
+	// We have removed these because we want to insert them into a different position.
+	array_splice( $toolbar2, 1, 0, 'hr' );
+	array_splice( $toolbar2, 1, 0, 'strikethrough' );
+	array_splice( $toolbar2, count( $toolbar2 ) - 1, 0, 'wp_more' );
+
+	// Convert back to original format.
+	$mceInit['toolbar1'] = implode( ',', $toolbar1 );
+	$mceInit['toolbar2'] = implode( ',', $toolbar2 );
+
+	return $mceInit;
+
+}
+
+// Modify Tiny_MCE init
+add_filter( 'tiny_mce_before_init', __NAMESPACE__ . '\\modify_tinyMCE4', 10, 2 );


### PR DESCRIPTION
- [x] Remove post thumbnail support since it's not used. 
- [x] Remove Tiny MCE buttons that aren't necessary.

Personally I think there are too many buttons enabled by default in TinyMCE. I'd like to remove a few, and move some lesser used ones into the collapsed row. 

Completely removed are underline, text color, text alignment buttons, indent/outdent. Have I been too keen in cutting things you might be using? 
