### PR TITLE
show private posts in fallback search

### DIFF
--- a/inc/search.php
+++ b/inc/search.php
@@ -110,6 +110,8 @@ function fallback_search_request( $query ) {
 		's'              => $query,
 		'post_type'      => get_post_types( [ 'public' => true ] ),
 		'posts_per_page' => 50,
+		'post_status'    => [ 'publish', 'private' ],
+		'perm'           => 'readable',
 	];
 
 	$search_query = new WP_Query( $search_query_args );


### PR DESCRIPTION
Elastic search is broken right now, which shows that the fallback search doesn't include private posts. 