### PR TITLE
Allow private redirect target to be set in admin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,6 +14,7 @@ require_once( __DIR__ . '/inc/page-history.php' );
 require_once( __DIR__ . '/inc/search.php' );
 require_once( __DIR__ . '/inc/editor-mods.php' );
 require_once( __DIR__ . '/inc/updates.php' );
+require_once( __DIR__ . '/inc/customizer.php' );
 
 add_action( 'after_setup_theme',  __NAMESPACE__ . '\\setup' );
 add_action( 'after_setup_theme',  __NAMESPACE__ . '\\content_width', 0 );
@@ -64,13 +65,17 @@ function setup() {
 		'before_title'  => '<h3 class="widget-title">',
 		'after_title'   => '</h3>'
 	] );
-	
+
 	// Filter next/prev post classes.
 	add_filter( 'next_posts_link_attributes',     __NAMESPACE__ . '\\posts_link_attributes_next' );
 	add_filter( 'previous_posts_link_attributes', __NAMESPACE__ . '\\posts_link_attributes_prev' );
 
 	add_filter( 'private_title_format', __NAMESPACE__ . '\\filter_private_title_format' );
 	add_filter( 'wp_link_pages_link', __NAMESPACE__ . '\\multi_page_links_markup', 10, 2 );
+
+	if ( ! is_user_logged_in() ) {
+		add_action( 'template_redirect', __NAMESPACE__ . '\\redirect_private_pages' );
+	}
 
 }
 
@@ -189,9 +194,9 @@ function posts_link_attributes_prev() {
  *
  * @return string Title format.
  */
-add_filter( 'private_title_format', function( $format ) {
+function filter_private_title_format( $format ) {
 	return '🔒 %s';
-} );
+}
 
 /**
  * Handle the markup for multi-page posts.
@@ -209,13 +214,25 @@ function multi_page_links_markup( $link, $i ) {
 }
 
 /**
- * Redirect private pages to a hiring page if a user is logged out
+ * Redirect private pages to a defined page.
+ *
+ * Note this is only hooked in when not logged in.
  */
 function redirect_private_pages() {
-	$queried_object = get_queried_object();
-	if ( isset( $queried_object->post_status ) && 'private' === $queried_object->post_status && ! is_user_logged_in() ) {
-		wp_redirect( home_url( '/join-human-made/' ) );
+
+	$queried_object_id = get_queried_object_id();
+
+	if ( $queried_object_id && 'private' === get_post_status( $queried_object_id ) ) {
+
+		$redirect = home_url();
+
+		if ( $redirect_target_id = get_theme_mod( 'private-page-redirect' ) ) {
+			if ( $permalink = get_permalink( $redirect_target_id ) ) {
+				$redirect = $permalink;
+			}
+		}
+
+		wp_safe_redirect( $redirect );
 		exit();
 	}
 }
-add_action( 'pre_get_posts', 'HM_Handbook\redirect_private_pages' );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace HM_Handbook\Customizer;
+
+use WP_Customize_Control;
+
+add_action( 'customize_register' , __NAMESPACE__ . '\\register' );
+
+function register( $wp_customize ) {
+
+	// 1. Define a new section of the Theme Customizer
+	$wp_customize->add_section( 'misc_settings',
+		array(
+			'title'       => __( 'HM Handbook Theme Settings', 'hm-handbook' ),
+			'priority'    => 10,
+			'capability'  => 'edit_theme_options',
+			'description' => __( 'Configure the HM Handbook theme.', 'hm-handbook' ),
+		)
+	);
+
+	// Add setting for private page redirect.
+	$wp_customize->add_setting( 'private-page-redirect', [
+		'type'              => 'theme_mod',
+		'capability'        => 'edit_theme_options',
+		'transport'         => 'postMessage',
+		'sanitize_callback' => 'absint',
+	] );
+
+
+	// Add controls for private page redirect setting.
+	$wp_customize->add_control( new WP_Customize_Control( $wp_customize, 'hm_handbook_private_page_redirect', [
+		'label'    => __( 'Private page redirect target (page ID)', 'hm-handbook' ),
+		'section'  => 'misc_settings',
+		'settings' => 'private-page-redirect',
+	] ) );
+
+}


### PR DESCRIPTION
#75 

Add customiser control for setting redirect target. 

Note - currently you just have to add the post ID. I figured this will do for now, but we can revisit and add a proper post-select control. Only problem is this isn't supported in core right now so will need to do custom or find a library.