### PR TITLE
Fix NPM install prod deploy error

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -1,5 +1,4 @@
 #!/bin/sh
 
 npm install
-npm install gulp gulp-cli
 node_modules/gulp-cli/bin/gulp.js

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "diff-match-patch": "^1.0.0",
     "exports-loader": "^0.6.3",
     "gulp": "^3.9.0",
+    "gulp-cli": "^1.4.0",
     "gulp-postcss": "^6.1.0",
     "gulp-sass": "^2.3.1",
     "gulp-sass-lint": "^1.2.0",


### PR DESCRIPTION
We've been running into an issue on https://github.com/humanmade/platform-docs-site when deploying to our prod environment.

On first deploy after deleting the build directory on the build server, we get a successful deploy, on subsequent deploys we hit an NPM error:

```
>  ERR! Linux 3.13.0-36-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install" "gulp" "gulp-cli"
npm ERR! node v4.4.5
npm ERR! npm  v2.15.5
npm ERR! path /builds/platform-docs/content/themes/hm-handbook-theme/node_modules/.bin/gulp
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall unlink

npm ERR! enoent ENOENT: no such file or directory, unlink '/builds/platform-docs/content/themes/hm-handbook-theme/node_modules/.bin/gulp'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent 
> 
> npm ERR! Please include the following file with any support request:
npm ERR!     /builds/platform-docs/content/themes/hm-handbook-theme/npm-debug.log
> .build-script: 5: .build-script: node_modules/gulp-cli/bin/gulp.js: not found
```

Looks like this is due to trying to install gulp twice, once through dependency in package.json and once due to `npm install gulp gulp-cli` in .build-script. The issue is reproducible on master branch locally by calling `sh .build-script` twice in succession 

cc @roborourke 