### PR TITLE
Add anchors for headings in handbook pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -230,3 +230,22 @@ function redirect_private_pages_to_join_page() {
 }
 
 add_action( 'template_redirect', __NAMESPACE__ . '\\redirect_private_pages_to_join_page' );
+
+/**
+ * Add id attribute to <h1>, <h2>, <h3>, <h4>, <h5> tags
+ *
+ * @param string $content Content of the current post.
+ *
+ * @return string $content The filtered post content.
+ */
+function anchor_content_headings( $content ) {
+    $content = preg_replace_callback( "/\<h([1|2|3|4|5])\>(.*?)\<\/h([1|2|3|4|5])\>/", function ( $matches ) {
+      $hTag = $matches[1];
+      $title = $matches[2];
+      $slug = sanitize_title_with_dashes( $title );
+      return '<a href="#'. $slug .'"><h'. $hTag .' id="' . $slug . '">' . $title . '</h'. $hTag .'></a>';
+    }, $content );
+
+    return $content;
+}
+  add_filter( 'the_content', __NAMESPACE__ . '\\anchor_content_headings' );


### PR DESCRIPTION
When deep-linking handbook content it's not easy to get a URL directly to the relevant heading ie:

1. Page https://handbook.hmn.md/working-here/continuous-improvement/personal-development-plan/
2. Relevant heading of interest `HOW AND WHEN SHOULD I UPDATE MY PDP?` 
3. There is no way for readers to quickly get a link to sub-content or headings.

Why this is useful? When sharing specific handbook information (policies, or specific policies etc) we will share the page link, then tell the person to scroll to x heading. So much mental weight can be lifted by matching the reader experience with current day expectations.

Related: https://github.com/humanmade/H2/issues/418 however - the code there may not be instantly portable.