### PR TITLE
Show private pages in recent updates widget for logged in users

### DIFF
--- a/inc/updates.php
+++ b/inc/updates.php
@@ -9,7 +9,14 @@ namespace HM_Handbook;
  */
 function display_latest( $latest = 'posts' ) {
 
-	$args = [ 'post_type' => 'page' ];
+	if ( is_user_logged_in() ) {
+		$args = array(
+			'post_status' => array( 'publish', 'private' ),
+			'post_type'   => 'page'
+		);
+	} else {
+		$args = [ 'post_type' => 'page' ];
+	}
 
 	if ( 'edits' === $latest ) {
 		$args = array_merge( $args, [ 'orderby' => 'modified', 'suppress_filters' => false ] );


### PR DESCRIPTION
On the homepage we show a list of recently added and recently edited pages. However they only show public pages. If you’re logged in then they should show private pages too.