### PR TITLE
Allow searching for private handbook entries

### DIFF
--- a/inc/search.php
+++ b/inc/search.php
@@ -110,7 +110,7 @@ function fallback_search_request( $query ) {
 	];
 
 	if ( is_user_logged_in() ) {
-		$search_query_argsp['post_status'][] = 'private';
+		$search_query_args['post_status'][] = 'private';
 	}
 
 	$search_query = new WP_Query( $search_query_args );


### PR DESCRIPTION
Just noticed this typo which was preventing search queries from hitting private pages in the handbook.

(I was originally looking at the source to see why we weren't using Elasticsearch here, which would make this fix obsolete. But this is a minor typo that was easy to fix so I figured I'd open it as a PR first.)