### PR TITLE
Deploy new brand colors to handbook theme

### DIFF
--- a/assets/src/scripts/components/SearchBar/SearchBar.js
+++ b/assets/src/scripts/components/SearchBar/SearchBar.js
@@ -21,7 +21,7 @@ export default class SearchBar extends Component {
 		let searchBarClassNames = classNames({
 			'search-bar':              true,
 			'search-bar--focused':     this.state.focused,
-			'search-bar--has-results': this.state.focused,
+			'search-bar--has-results': this.state.results.length,
 			'search-bar--loading':     this.state.loading,
 		});
 

--- a/assets/src/styles/base/_layout.scss
+++ b/assets/src/styles/base/_layout.scss
@@ -20,7 +20,6 @@ body {
 .site-sidebar {
 
 	padding: $margin-vertical-sm $gutter-width * 2;
-	min-height: calc( 100vh - 6rem ); // For IE11 & 10
 
 	@media #{ $mq-md-up } {
 		width: 300px;

--- a/assets/src/styles/components/_PageHistory.scss
+++ b/assets/src/styles/components/_PageHistory.scss
@@ -1,4 +1,6 @@
 
+@use "sass:math";
+
 .PageHistory_Diff-Added {
 	background: $color-success;
 	text-decoration: none;
@@ -13,7 +15,7 @@
 	width: 100%;
 	position: relative;
 	margin: $base-line-height 0;
-	padding: #{ $base-line-height / 2 } #{ $gutter-width };
+	padding: #{ $base-line-height * 0.5 } #{ $gutter-width };
 	background: $color-pagehistory-background;
 	border-radius: 2px;
 
@@ -84,17 +86,17 @@
 	color: $color-pagehistory-list;
 	list-style: none;
 	position: relative;
-	margin: #{ $base-line-height / 4 } 0;
-	padding-left: #{ $gutter-width / 2 };
+	margin: #{ $base-line-height * 0.25 } 0;
+	padding-left: #{ $gutter-width * 0.5 };
 
 	&:after {
 		content: " ";
 		display: block;
 		border-left: 1px solid $border-color-darken;
 		position: absolute;
-		top: $base-line-height / 2;
-		bottom: calc( #{ $base-line-height / 2 } + 2px );
-		left: $gutter-width / 4 - 1px;
+		top: $base-line-height * 0.5;
+		bottom: calc( #{ $base-line-height * 0.5 } + 2px );
+		left: $gutter-width * 0.25 - 1px;
 	}
 
 	& + .btn {
@@ -107,10 +109,10 @@
 .PageHistory_List_Item {
 
 	position: relative;
-	padding: 0 0 0 #{ $gutter-width / 2 };
+	padding: 0 0 0 #{ $gutter-width * 0.5 };
 
 	a {
-		padding: #{ $base-line-height / 8 } 0;
+		padding: #{ $base-line-height * 0.125 } 0;
 		display: block;
 	}
 
@@ -135,8 +137,8 @@
 		background: $border-color-darken;
 		border-radius: 100%;
 		position: absolute;
-		left: $gutter-width / -4 - 3px;
-		top: $base-line-height / 2;
+		left: math.div($gutter-width, -4) - 3px;
+		top: $base-line-height * 0.5;
 		margin-top: 0;
 		z-index: 1;
 	}
@@ -146,7 +148,7 @@
 		width: 9px;
 		height: 9px;
 		margin-top: -3px;
-		left: $gutter-width / -4 - 5px;
+		left: math.div($gutter-width, -4) - 5px;
 	}
 
 	&.PageHistory_List_Item-Active:after {
@@ -163,7 +165,7 @@
 	display: none; // Only shown when active.
 	white-space: pre-wrap;
 	background: $color-pagehistory-background;
-	padding: $base-line-height / 2 $gutter-width / 2;
+	padding: $base-line-height * 0.5 $gutter-width * 0.5;
 	font-family: $font-family-code;
 	word-wrap: break-word;
 }

--- a/assets/src/styles/components/_Pagination.scss
+++ b/assets/src/styles/components/_Pagination.scss
@@ -25,20 +25,20 @@
 		@extend .btn;
 		@extend .btn--small;
 		@extend .btn--tertiary;
-		margin-right: $gutter-width / 4;
+		margin-right: $gutter-width * 0.25;
 	}
 
 	.Pagination-Current {
 		@extend .btn;
 		@extend .btn--small;
 		@extend .btn--secondary;
-		margin-right: $gutter-width / 4;
+		margin-right: $gutter-width * 0.25;
 		pointer-events: none;
 	}
 
 	.Pagination-Label {
 		line-height: 2.25rem;
-		margin-right: $gutter-width / 4;
+		margin-right: $gutter-width * 0.25;
 		display: inline-block;
 		vertical-align: middle;
 		margin-bottom: .75rem;

--- a/assets/src/styles/components/_comments.scss
+++ b/assets/src/styles/components/_comments.scss
@@ -88,7 +88,7 @@
 .comment-awaiting-moderation {
 	background: $hm-light-grey;
 	border-radius: 2px;
-	padding: $base-line-height / 2 $gutter-width;
+	padding: $base-line-height * 0.5 $gutter-width;
 	margin-left: calc( ( -1 * $comment_avatar_width ) - #{ $gutter-width } );
 	clear: both;
 }
@@ -99,7 +99,7 @@
 
 		background: $hm-light-grey;
 		border-radius: 2px;
-		padding: $base-line-height / 2 $gutter-width;
+		padding: $base-line-height * 0.5 $gutter-width;
 
 		a {
 			color: inherit;
@@ -110,7 +110,7 @@
 		@include font-heading;
 		color: $hm-dark-grey;
 		@include text-sm;
-		margin-top: $base-line-height / 2;
+		margin-top: $base-line-height * 0.5;
 		margin-bottom: 0;
 	}
 

--- a/assets/src/styles/components/_footer.scss
+++ b/assets/src/styles/components/_footer.scss
@@ -1,19 +1,4 @@
 .Footer {
-
-	.hm-link {
-		&:hover,
-		&:active,
-		&:focus {
-			color: $hm-red;
-
-			.hm-logo--tiny {
-				background-image: url( "#{ $images-path }/logos/logo-tiny-red.svg" );
-				opacity: 1;
-			}
-		}
-
-	}
-
 	.footer-content {
 		@include font-body;
 

--- a/assets/src/styles/components/_header.scss
+++ b/assets/src/styles/components/_header.scss
@@ -98,22 +98,37 @@
 	}
 
 	.search-bar__field {
-		border: 2px solid rgba( 255, 255, 255, 0.8 );
-		background: none;
-		color: #FFF;
+		border-color: var( --hm-dark-grey );
+		background: var( --hm-light-grey );
+		color: var( --hm-dark-grey );
 		float: right;
 		margin: 0;
 		padding-right: 0;
 		width: 100%;
 		height: $base-line-height * 2;
+		transition: color .2s, border-color .2s, background .2s;
 
 		&::placeholder {
-			color: rgba( #FFF, 1 );
+			color: white;
 		}
 
-		&:hover,
+		&:placeholder-shown {
+			border-color: rgba( 255, 255, 255, 0.8 );
+			background: transparent;
+
+			.search-bar__submit:after {
+				$iconSrc: iconSrc( "search", "white" );
+			}
+		}
+
 		&:focus {
-			border: 2px solid rgba( 255, 255, 255, 1 );
+			background: var( --hm-light-grey );
+			border-color: var( --hm-dark-grey );
+			color: var( --hm-dark-grey );
+
+			&::placeholder {
+				color: var( --hm-dark-grey );
+			}
 		}
 	}
 
@@ -133,7 +148,7 @@
 		opacity: .75;
 
 		&:after {
-			$iconSrc: iconSrc( "search", "white" );
+			$iconSrc: iconSrc( "search", "black" );
 			background: url( $iconSrc ) center center no-repeat;
 			content: " ";
 			display: block;
@@ -146,10 +161,9 @@
 
 		&:hover,
 		&:focus {
-			background: rgba( 0, 0, 0, 0.2 );
+			background: rgba( 0, 0, 0, 0.1 );
 			border: none;
 		}
-
 	}
 
 	.search-bar__results {
@@ -158,24 +172,16 @@
 		top: 100%;
 		left: 0;
 		right: 0;
-		border: 2px solid $white;
-		border-top: none;
-		background: $color-primary;
+		border: 2px solid var( --hm-dark-grey );
+		border-top-color: transparent;
+		background: var( --hm-light-grey );
 		padding: 0;
 		border-radius: 0 0 2px 2px;
-		color: #FFF;
+		color: var( --hm-dark-grey );
 		margin: 0;
 		list-style: none;
 		z-index: 50;
 		overflow-x: hidden;
-	}
-
-	&.search-bar--has-results {
-		.search-bar__field {
-			border-bottom: none;
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
-		}
 	}
 
 	.search-bar__result {
@@ -185,43 +191,39 @@
 		padding: 0;
 		margin: 0;
 
-		a:link,
-		a:visited,
-		a:hover,
-		a:focus {
-			color: #FFF;
-			text-decoration: none;
+		a {
 			border: none;
+			text-decoration: none;
 		}
 
 		a:link {
 			padding: #{ $base-line-height * 0.5 } #{ $gutter-width };
 			margin: 0;
-			border-top: 1px solid rgba( $white, 0.5 );
 			display: block;
 
 			&:focus,
 			&:hover {
-				background: rgba( 255, 255, 255, .2 );
-				border-top: 1px solid rgba( $white, 0.8 );
-				border-bottom: 1px solid rgba( $white, 0.8 );
-				margin-bottom: -1px;
+				background: rgba( 0, 0, 0, .1 );
 				outline: none;
 				transition: none;
 			}
 		}
 	}
 
+	.search-bar__result + .search-bar__result {
+		border-top: 1px solid var( --hm-dark-grey );
+	}
+
 	.search-bar__results__info,
 	.search-bar__result__title,
 	.search-bar__result__text {
 		@include text-sm;
-		color: #FFF;
+		color: var( --hm-dark-grey );
 		margin: 0;
 	}
 
 	.search-bar__results__info {
-		border-top: 1px solid rgba( $white, 0.8 );
+		border-top: 1px solid var( --hm-dark-grey );
 		padding: #{ $base-line-height * 0.5 } #{ $gutter-width };
 	}
 
@@ -229,7 +231,8 @@
 		margin: 0 0 #{ $gutter-width * 0.5 } 0;
 	}
 
-	&.search-bar--focused {
+	&.search-bar--focused,
+	&.search-bar--has-results:focus-within {
 
 		@media #{ $mq-md-up } {
 			.search-bar__container {
@@ -237,10 +240,17 @@
 				transition: width ease-in-out .1s;
 			}
 		}
+	}
 
-		&.search-bar--has-results .search-bar__results {
-			display: block;
+	&.search-bar--has-results:focus-within {
+		.search-bar__field {
+			border-bottom: none;
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
 		}
 
+		.search-bar__results {
+			display: block;
+		}
 	}
 }

--- a/assets/src/styles/components/_header.scss
+++ b/assets/src/styles/components/_header.scss
@@ -116,8 +116,9 @@
 			border-color: rgba( 255, 255, 255, 0.8 );
 			background: transparent;
 
-			.search-bar__submit:after {
+			+ .search-bar__submit::after {
 				$iconSrc: iconSrc( "search", "white" );
+				background: url( $iconSrc ) center center no-repeat;
 			}
 		}
 
@@ -128,6 +129,11 @@
 
 			&::placeholder {
 				color: var( --hm-dark-grey );
+			}
+
+			+ .search-bar__submit::after {
+				$iconSrc: iconSrc( "search", "black" );
+				background: url( $iconSrc ) center center no-repeat;
 			}
 		}
 	}
@@ -147,7 +153,7 @@
 		overflow: hidden;
 		opacity: .75;
 
-		&:after {
+		&::after {
 			$iconSrc: iconSrc( "search", "black" );
 			background: url( $iconSrc ) center center no-repeat;
 			content: " ";
@@ -161,7 +167,7 @@
 
 		&:hover,
 		&:focus {
-			background: rgba( 0, 0, 0, 0.1 );
+			background: none;
 			border: none;
 		}
 	}

--- a/assets/src/styles/components/_header.scss
+++ b/assets/src/styles/components/_header.scss
@@ -25,7 +25,7 @@
 		width: 210px;
 		height: 40px;
 		margin: calc( ( #{ $base-line-height * 2 } - 40px ) / 2 ) auto;
-		margin-top: calc( #{ $base-line-height / 2 } + ( ( #{ $base-line-height * 2 } - 40px ) / 2 ) );
+		margin-top: calc( #{ $base-line-height * 0.5 } + ( ( #{ $base-line-height * 2 } - 40px ) / 2 ) );
 
 		&:hover {
 			border: none;
@@ -195,7 +195,7 @@
 		}
 
 		a:link {
-			padding: #{ $base-line-height / 2 } #{ $gutter-width };
+			padding: #{ $base-line-height * 0.5 } #{ $gutter-width };
 			margin: 0;
 			border-top: 1px solid rgba( $white, 0.5 );
 			display: block;
@@ -222,11 +222,11 @@
 
 	.search-bar__results__info {
 		border-top: 1px solid rgba( $white, 0.8 );
-		padding: #{ $base-line-height / 2 } #{ $gutter-width };
+		padding: #{ $base-line-height * 0.5 } #{ $gutter-width };
 	}
 
 	.search-bar__result__title {
-		margin: 0 0 #{ $gutter-width / 2 } 0;
+		margin: 0 0 #{ $gutter-width * 0.5 } 0;
 	}
 
 	&.search-bar--focused {

--- a/assets/src/styles/components/_nav-accordion.scss
+++ b/assets/src/styles/components/_nav-accordion.scss
@@ -90,7 +90,7 @@
 
 	> ul {
 		overflow: hidden;
-		margin-left: $gutter-width / 2;
+		margin-left: $gutter-width * 0.5;
 	}
 
 }
@@ -119,7 +119,7 @@
 
 	.NavAccordion_Anchor:after {
 		content: " ";
-		width: $gutter-width / 2;
+		width: $gutter-width * 0.5;
 		border-bottom: 1px solid $border-color;
 		position: absolute;
 		top: 19px;

--- a/assets/src/styles/components/_sidebar.scss
+++ b/assets/src/styles/components/_sidebar.scss
@@ -1,6 +1,7 @@
 .site-sidebar {
 
-	background-color: $color-sidebar-background;
+	background-color: var( --hm-light-blue );
+	color: var( --hm-dark-grey );
 	padding: $base-line-height $gutter-width * 2;
 
 	ul {

--- a/assets/src/styles/components/_sidebar.scss
+++ b/assets/src/styles/components/_sidebar.scss
@@ -6,4 +6,8 @@
 	ul {
 		margin: 0;
 	}
+
+	a:hover {
+		text-decoration: underline;
+	}
 }

--- a/assets/src/styles/components/_updates.scss
+++ b/assets/src/styles/components/_updates.scss
@@ -5,13 +5,13 @@
 
 	&--heading {
 		flex: 1 0 100%;
-		margin: 0 0 #{ $gutter-width / 2 };
+		margin: 0 0 #{ $gutter-width * 0.5 };
 	}
 
 	&--box {
 		background-color: $hm-light-grey;
 		padding: $gutter-width;
-		margin: 0 #{ $gutter-width / 2 } $gutter-width 0;
+		margin: 0 #{ $gutter-width * 0.5 } $gutter-width 0;
 		flex: 1 0 100%;
 
 		@media ( min-width: 1400px ) {
@@ -27,7 +27,7 @@
 	&--list-item {
 		list-style: none;
 		border-bottom: 1px solid darken( $hm-light-grey, 10% );
-		padding: #{ $gutter-width / 3 } 0;
+		padding: #{ $gutter-width * 0.333 } 0;
 
 		&:last-child {
 			padding-bottom: 0;

--- a/assets/src/styles/login.scss
+++ b/assets/src/styles/login.scss
@@ -26,7 +26,7 @@ html {
 
 .login #backtoblog,
 .login #nav {
-	margin: $base-line-height / 2 auto;
+	margin: $base-line-height * 0.5 auto;
 	a {
 		color: $white;
 		@include text-sm;
@@ -67,7 +67,7 @@ html {
 	background-color: $login-form-background;
 	width: 100%;
 	border: none;
-	padding: $base-line-height / 2 $gutter-width;
+	padding: $base-line-height * 0.5 $gutter-width;
 	border-radius: 2px;
 }
 

--- a/assets/src/styles/theme.scss
+++ b/assets/src/styles/theme.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $images-path: "./../../../vendor/hm-pattern-library/assets/images" !default;
 
 // External
@@ -42,8 +44,8 @@ $images-path: "./../../../vendor/hm-pattern-library/assets/images" !default;
 			position: absolute;
 			top: 50%;
 			left: 50%;
-			margin-top: $base-line-height / -2;
-			margin-left: $base-line-height / -2;
+			margin-top: math.div($base-line-height, -2);
+			margin-left: math.div($base-line-height, -2);
 		}
 
 		&:after {
@@ -53,9 +55,9 @@ $images-path: "./../../../vendor/hm-pattern-library/assets/images" !default;
 	}
 
 	.search-bar_Results-Info {
-		margin: 0 #{ $gutter-width / 2 } #{ $base-line-height / 2 } #{ $gutter-width / 2 };
+		margin: 0 #{ $gutter-width * 0.5 } #{ $base-line-height * 0.5 } #{ $gutter-width * 0.5 };
 		border-top: 1px solid desaturate( $color-primary, 5% );
-		padding-top: $base-line-height / 2;
+		padding-top: $base-line-height * 0.5;
 		font-size: 1rem;
 		line-height: $base-line-height;
 		color: #FFF;

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "humanmade/hm-handbook-theme",
+    "version": "0.0.1",
+    "description": "The theme for the public Human Made handbook.",
+    "minimum-stability": "stable",
+    "type": "wordpress-theme",
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
+    }
+}

--- a/footer.php
+++ b/footer.php
@@ -16,7 +16,7 @@ namespace HM_Handbook;
 
 			<div class="site-footer Footer">
 
-				<p><a href="https://hmn.md" class="hm-link"><span class="hm-logo hm-logo--tiny"></span>Made by Humans</a></p>
+				<p><span class="hm-logo hm-logo--tiny hm-logo--red"></span> <a href="https://hmn.md" class="hm-link">Made by Humans</a></p>
 
 				<div class="footer-content">
 					<?php dynamic_sidebar( 'footer-content' ); ?>


### PR DESCRIPTION
This PR deploys the brand color updates from humanmade/hm-pattern-library#173 to the HM Handbook theme, and adjusts theme styling to work with the new colors (drop red for small textual elements, alter search interface coloring since new red is too bright to use as a legible background, etc)

**Before** | **After**
----------- | ---------
<img width="1320" alt="image" src="https://user-images.githubusercontent.com/442115/209239801-f97c70fd-cb0e-440b-a330-5d134c7eac2e.png"> | <img width="1314" alt="image" src="https://user-images.githubusercontent.com/442115/209239631-e3c5cd76-209a-4a0b-b4f3-a19828b29373.png">

The addition of a composer.json is a bit premature since, as this depends on a submodule for its build, it is easier to keep it as a submodule within the HMN network until we get a build stood up for it.
