### PR TITLE
122: Add font override for body text

### DIFF
--- a/assets/src/styles/theme.scss
+++ b/assets/src/styles/theme.scss
@@ -26,6 +26,12 @@ $images-path: "./../../../vendor/hm-pattern-library/assets/images" !default;
 // Plugins
 @import "components/feature-requests";
 
+// Global font override
+body {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-weight: 400;
+}
+
 .article {
 	position: relative;
 }


### PR DESCRIPTION
This changes the default font stack for the handbook to the system default font stack from WordPress, following similar changes on our intranet sites. Proxima Nova remains in use for menus and headlines, for now.

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/442115/209403839-3b5b00b4-03bb-4fb3-8f3d-15a430c4bc15.png">
