### PR TITLE
Add build action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - add-build-action
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -15,7 +16,7 @@ jobs:
     uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@04c32a93e52ae987095f144105745a501d6207c8 # v0.2.0
     with:
       node_version: 12
-      source_branch: main
+      source_branch: add-build-action
       release_branch: release
       built_asset_paths: build
       build_script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,6 @@ jobs:
       release_branch: release
       built_asset_paths: build
       build_script: |
+        git submodule update --init vendor/hm-pattern-library
         npm ci --legacy-peer-deps
         npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Build to Release branch
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: "Build to release branch"
+    uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@04c32a93e52ae987095f144105745a501d6207c8 # v0.2.0
+    with:
+      node_version: 12
+      source_branch: main
+      release_branch: release
+      built_asset_paths: build
+      build_script: |
+        npm ci --legacy-peer-deps
+        npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       node_version: 12
       source_branch: add-build-action
       release_branch: release
-      built_asset_paths: build
+      built_asset_paths: assets/dist
       build_script: |
         git submodule update --init vendor/hm-pattern-library
         npm ci --legacy-peer-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - add-build-action
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -16,7 +15,7 @@ jobs:
     uses: humanmade/hm-github-actions/.github/workflows/build-and-release-node.yml@04c32a93e52ae987095f144105745a501d6207c8 # v0.2.0
     with:
       node_version: 12
-      source_branch: add-build-action
+      source_branch: main
       release_branch: release
       built_asset_paths: assets/dist
       build_script: |

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://handbook.hmn.md/
 Author: Human Made Limited
 Author URI: http://hmn.md
 Description: Theme for the Human Made employee handbook site.
-Version: 1.1.0
+Version: 1.1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: hm-handbook.


### PR DESCRIPTION
## Description
To simplify consumption of this repository (removing the need for a consumer-side build), this PR adds a standardized build workflow action which will compile and commit the `build/` folder to a `release` branch. The release branch can then be depended upon as `dev-release` in composer (preferred), or tracked as a submodule.

## Steps to Test
Theme should work as normal without a separate build step when checking out the "release" branch.
