### PR TITLE
Bump theme version to cachebust

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://handbook.hmn.md/
 Author: Human Made Limited
 Author URI: http://hmn.md
 Description: Theme for the Human Made employee handbook site.
-Version: 1.1.1
+Version: 1.2.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: hm-handbook.


### PR DESCRIPTION
`theme.css?ver=1.1.1` is aggressively CDN-cached, preventing #132 from going live